### PR TITLE
internal: primarily use the HTTP client provided in the context

### DIFF
--- a/internal/transport.go
+++ b/internal/transport.go
@@ -33,6 +33,11 @@ func RegisterContextClientFunc(fn ContextClientFunc) {
 }
 
 func ContextClient(ctx context.Context) (*http.Client, error) {
+	if ctx != nil {
+		if hc, ok := ctx.Value(HTTPClient).(*http.Client); ok {
+			return hc, nil
+		}
+	}
 	for _, fn := range contextClientFuncs {
 		c, err := fn(ctx)
 		if err != nil {
@@ -41,9 +46,6 @@ func ContextClient(ctx context.Context) (*http.Client, error) {
 		if c != nil {
 			return c, nil
 		}
-	}
-	if hc, ok := ctx.Value(HTTPClient).(*http.Client); ok {
-		return hc, nil
 	}
 	return http.DefaultClient, nil
 }

--- a/internal/transport_test.go
+++ b/internal/transport_test.go
@@ -1,0 +1,38 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+import (
+	"net/http"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestContextClient(t *testing.T) {
+	rc := &http.Client{}
+	RegisterContextClientFunc(func(context.Context) (*http.Client, error) {
+		return rc, nil
+	})
+
+	c := &http.Client{}
+	ctx := context.WithValue(nil, HTTPClient, c)
+
+	hc, err := ContextClient(ctx)
+	if err != nil {
+		t.Fatalf("want valid client; got err = %v", err)
+	}
+	if hc != c {
+		t.Fatalf("want context client = %p; got = %p", c, hc)
+	}
+
+	hc, err = ContextClient(context.TODO())
+	if err != nil {
+		t.Fatalf("want valid client; got err = %v", err)
+	}
+	if hc != rc {
+		t.Fatalf("want registered client = %p; got = %p", c, hc)
+	}
+}


### PR DESCRIPTION
Change-Id: I99eaf1480ebdfbaa5b64ac17203fbf14bf887962
Reviewed-on: https://go-review.googlesource.com/17396
Reviewed-by: Brad Fitzpatrick bradfitz@golang.org
Reviewed-by: Chris Broadfoot cbro@golang.org
